### PR TITLE
feat : Add user body fat and IMC calculations to CLI

### DIFF
--- a/src/cli/cli.go
+++ b/src/cli/cli.go
@@ -4,9 +4,22 @@ import (
 	"fmt"
 	"bufio"
 	"os"
+	"gotracker/structs"
 )
 
 func Open() {
+	// Créer un utilisateur fictif
+	user := suser.SUser{
+		ID:           1,
+		Firstname:    "John",
+		Lastname:     "Doe",
+		Age:          30,
+		Weight:       70,  // Poids en kg
+		Height:       175, // Taille en cm
+		BodyFat:      15.5,
+		TargetWeight: 65,
+	}
+
 	// Define the reader to read from standard input
 	reader := bufio.NewReader(os.Stdin)
 
@@ -26,7 +39,15 @@ func Open() {
 			fmt.Println("Available commands:")
 			fmt.Println("  - exit: Exit the CLI")
 			fmt.Println("  - help: Show this help message")
+			fmt.Println("  - bodyfat: Display the user's body fat percentage")
+            fmt.Println("  - imc: Display the user's Body Mass Index (IMC)")
+		
+		case "bodyfat\n":
+            fmt.Printf("Body Fat: %.2f%%\n", user.GetBodyFat())
 
+        case "imc\n":
+            fmt.Printf("IMC: %.2f\n", user.GetIMC())
+	
 		default:
 			fmt.Println("Unknown command. Type 'help' for a list of commands.")
 		}

--- a/src/structs/user.go
+++ b/src/structs/user.go
@@ -1,7 +1,6 @@
 package suser
 
 import (
-	"fmt"
 	"math"
 )
 
@@ -13,6 +12,18 @@ type SUser struct {
 	Weight int
 	Height int
 	BodyFat float64
-	IMC float64
 	TargetWeight int
+}
+
+// GetBodyFat returns the BodyFat value of the user
+func (u *SUser) GetBodyFat() float64 {
+    return u.BodyFat
+}
+
+// GetIMC calculates and returns the IMC (Body Mass Index) of the user
+func (u *SUser) GetIMC() float64 {
+    if u.Height == 0 {
+        return 0 // Avoid division by zero
+    }
+    return float64(u.Weight) / math.Pow(float64(u.Height)/100, 2)
 }


### PR DESCRIPTION
This pull request introduces several new features and improvements to the CLI and user struct in the `gotracker` project. The most important changes include adding new commands to display user body metrics and implementing methods to calculate these metrics.

### New Features:

* [`src/cli/cli.go`](diffhunk://#diff-96360cb5dbd3e9bd9ddb6f9aacbc52f06bdccbe884fa00ff1d2864d4303d962cR42-R49): Added new commands `bodyfat` and `imc` to display the user's body fat percentage and Body Mass Index (IMC) respectively.

### Code Improvements:

* [`src/cli/cli.go`](diffhunk://#diff-96360cb5dbd3e9bd9ddb6f9aacbc52f06bdccbe884fa00ff1d2864d4303d962cR7-R22): Added a sample user object in the `Open` function to facilitate testing of the new commands.
* [`src/structs/user.go`](diffhunk://#diff-2002949c62a4b387ff4b952ca93356265237e99d0d4723762c9f5e0d80cfff40L16-R29): Removed the unused `IMC` field from the `SUser` struct.
* [`src/structs/user.go`](diffhunk://#diff-2002949c62a4b387ff4b952ca93356265237e99d0d4723762c9f5e0d80cfff40L16-R29): Implemented `GetBodyFat` and `GetIMC` methods in the `SUser` struct to calculate and return the user's body fat percentage and IMC respectively.